### PR TITLE
Update testsql

### DIFF
--- a/testsql
+++ b/testsql
@@ -1,1 +1,78 @@
-test
+create procedure syn.usp_ImportFileCustomerSeasonal
+	@ID_Record int
+as
+set nocount on
+begin
+	declare @RowCount int = (select count(*) from syn.SA_CustomerSeasonal)
+	declare @ErrorMessage varchar(max)
+
+-- Проверка на корректность загрузки
+	if not exists (
+	select 1
+	from syn.ImportFile as f
+	where f.ID = @ID_Record
+		and f.FlagLoaded = cast(1 as bit)
+	)
+		begin
+			set @ErrorMessage = 'Ошибка при загрузке файла, проверьте корректность данных'
+
+			raiserror(@ErrorMessage, 3, 1)
+			return
+		end
+
+	CREATE TABLE #ProcessedRows (
+		ActionType varchar(255),
+		ID int
+	)
+	
+	--Чтение из слоя временных данных
+	select
+		cc.ID as ID_dbo_Customer
+		,cst.ID as ID_CustomerSystemType
+		,s.ID as ID_Season
+		,cast(cs.DateBegin as date) as DateBegin
+		,cast(cs.DateEnd as date) as DateEnd
+		,cd.ID as ID_dbo_CustomerDistributor
+		,cast(isnull(cs.FlagActive, 0) as bit) as FlagActive
+	into #CustomerSeasonal
+	from syn.SA_CustomerSeasonal cs
+		join dbo.Customer as cc on cc.UID_DS = cs.UID_DS_Customer
+			and cc.ID_mapping_DataSource = 1
+		join dbo.Season as s on s.Name = cs.Season
+		join dbo.Customer as cd on cd.UID_DS = cs.UID_DS_CustomerDistributor
+			and cd.ID_mapping_DataSource = 1
+		join syn.CustomerSystemType as cst on cs.CustomerSystemType = cst.Name
+	where try_cast(cs.DateBegin as date) is not null
+		and try_cast(cs.DateEnd as date) is not null
+		and try_cast(isnull(cs.FlagActive, 0) as bit) is not null
+
+	-- Определяем некорректные записи
+	-- Добавляем причину, по которой запись считается некорректной
+	select
+		cs.*
+		,case
+			when cc.ID is null then 'UID клиента отсутствует в справочнике "Клиент"'
+			when cd.ID is null then 'UID дистрибьютора отсутствует в справочнике "Клиент"'
+			when s.ID is null then 'Сезон отсутствует в справочнике "Сезон"'
+			when cst.ID is null then 'Тип клиента в справочнике "Тип клиента"'
+			when try_cast(cs.DateBegin as date) is null then 'Невозможно определить Дату начала'
+			when try_cast(cs.DateEnd as date) is null then 'Невозможно определить Дату начала'
+			when try_cast(isnull(cs.FlagActive, 0) as bit) is null then 'Невозможно определить Активность'
+		end as Reason
+	into #BadInsertedRows
+	from syn.SA_CustomerSeasonal as cs
+	left join dbo.Customer as cc on cc.UID_DS = cs.UID_DS_Customer
+		and cc.ID_mapping_DataSource = 1
+	left join dbo.Customer as cd on cd.UID_DS = cs.UID_DS_CustomerDistributor and cd.ID_mapping_DataSource = 1
+	left join dbo.Season as s on s.Name = cs.Season
+	left join syn.CustomerSystemType as cst on cst.Name = cs.CustomerSystemType
+	where cc.ID is null
+		or cd.ID is null
+		or s.ID is null
+		or cst.ID is null
+		or try_cast(cs.DateBegin as date) is null
+		or try_cast(cs.DateEnd as date) is null
+		or try_cast(isnull(cs.FlagActive, 0) as bit) is null
+		
+end
+


### PR DESCRIPTION
        create procedure syn.usp_ImportFileCustomerSeasonal  
                   -- 1)Название процедуры usp_ImportFileCustomerSeasonal не соответствует хорошим практикам именования.
	             @ID_Record int
        as
        set nocount on
        begin
	          declare @RowCount int = (select count(*) from syn.SA_CustomerSeasonal)
	           declare @ErrorMessage varchar(max)

               --2)В коде отсутствуют комментарии, которые объяснили бы, что делает каждый блок кода. Добавление комментариев помогло бы другим разработчикам понять цель и логику этой процедуры.

              -- Проверка на корректность загрузки
              -- 3) В коде присутствует смешанное использование регистров для идентификаторов, что затрудняет чтение кода. Рекомендуется придерживаться единого стиля
               --4) В этом коде используется raiserror для генерации ошибки. Это может быть полезно, но отсутствует обработка ошибок. Обычно важно иметь обработку ошибок, чтобы код мог возвращать информацию об ошибках и принимать соответствующие меры.

	           if not exists (
	            select 1
	           from syn.ImportFile as f
	           where f.ID = @ID_Record
		                   and f.FlagLoaded = cast(1 as bit)
	)
		                  begin

	                                          set @ErrorMessage = 'Ошибка при загрузке файла, проверьте корректность данных'

			                        raiserror(@ErrorMessage, 3, 1)
			                        return
		end

	CREATE TABLE #ProcessedRows (ActionType varchar(255), ID int)
	
	 --Чтение из слоя временных данных
        --5)В коде создаются временные таблицы с использованием символа #. Важно учесть, что они будут доступны только в рамках текущей сессии и могут потерять данные при завершении сессии.
         --6) В коде многократно используется try_cast, чтобы проверить преобразование данных. Это может сделать код менее эффективным.
           --7) В SQL-коде важно документировать структуру базы данных с помощью комментариев к столбцам и таблицам, чтобы облегчить понимание схемы данных. */

	select
		cc.ID as ID_dbo_Customer
		,cst.ID as ID_CustomerSystemType
		,s.ID as ID_Season
		,cast(cs.DateBegin as date) as DateBegin
		,cast(cs.DateEnd as date) as DateEnd
		,cd.ID as ID_dbo_CustomerDistributor
		,cast(isnull(cs.FlagActive, 0) as bit) as FlagActive
	into #CustomerSeasonal
	from syn.SA_CustomerSeasonal cs
		join dbo.Customer as cc on cc.UID_DS = cs.UID_DS_Customer
			and cc.ID_mapping_DataSource = 1
		join dbo.Season as s on s.Name = cs.Season
		join dbo.Customer as cd on cd.UID_DS = cs.UID_DS_CustomerDistributor
			and cd.ID_mapping_DataSource = 1
		join syn.CustomerSystemType as cst on cs.CustomerSystemType = cst.Name
	where try_cast(cs.DateBegin as date) is not null
		and try_cast(cs.DateEnd as date) is not null
		and try_cast(isnull(cs.FlagActive, 0) as bit) is not null

	-- Определяем некорректные записи
	-- Добавляем причину, по которой запись считается некорректной
       --8) После объявления временных таблиц и операций над данными не указан блок END для завершения процедуры. Это важное нарушение структуры кода.*/
        --9)Код не имеет единообразных отступов, что делает его менее читаемым. Рекомендуется использовать одинаковые отступы для обеспечения четкой структуры кода.*/
          --10) Имена переменных, такие как @ID_Record, @RowCount, и @ErrorMessage, не соответствуют общепринятым стандартам именования. Рекомендуется использовать более понятные и описательные имена переменных.
          --11) В коде отсутствуют пробелы и отступы между операторами и ключевыми словами, что затрудняет его восприятие. Рекомендуется добавить пробелы для улучшения читаемости.
            --12) В некоторых частях кода применяются несколько операторов `JOIN` подряд, что делает его менее читаемым. Рекомендуется разбивать такие операторы на отдельные строки и правильно форматировать их.
            --13) `set nocount on` находится в начале процедуры, но его назначение не объяснено. Рекомендуется добавить комментарий, объясняющий, зачем он используется.
            --14) Некоторые имена таблиц и столбцов, такие как #ProcessedRows, не являются информативными. Рекомендуется использовать более описательные имена.
             --15) В строке raiserror(@ErrorMessage, 3, 1) сообщение об ошибке передается в качестве параметра @ErrorMessage. Это вполне легитимно, но было бы полезно добавить комментарий, который описывает, какое именно сообщение будет выведено.
              --16) В некоторых местах кода есть небольшие различия в форматировании (например, отступы между ключевыми словами join и таблицами)*/

	select
		cs.*
		,case
			when cc.ID is null then 'UID клиента отсутствует в справочнике "Клиент"'
			when cd.ID is null then 'UID дистрибьютора отсутствует в справочнике "Клиент"'
			when s.ID is null then 'Сезон отсутствует в справочнике "Сезон"'
			when cst.ID is null then 'Тип клиента в справочнике "Тип клиента"'
			when try_cast(cs.DateBegin as date) is null then 'Невозможно определить Дату начала'
			when try_cast(cs.DateEnd as date) is null then 'Невозможно определить Дату начала'
			when try_cast(isnull(cs.FlagActive, 0) as bit) is null then 'Невозможно определить Активность'
		end as Reason
	into #BadInsertedRows
	from syn.SA_CustomerSeasonal as cs
	left join dbo.Customer as cc on cc.UID_DS = cs.UID_DS_Customer
		and cc.ID_mapping_DataSource = 1
	left join dbo.Customer as cd on cd.UID_DS = cs.UID_DS_CustomerDistributor and cd.ID_mapping_DataSource = 1
	left join dbo.Season as s on s.Name = cs.Season
	left join syn.CustomerSystemType as cst on cst.Name = cs.CustomerSystemType
	where cc.ID is null
		or cd.ID is null
		or s.ID is null
		or cst.ID is null
		or try_cast(cs.DateBegin as date) is null
		or try_cast(cs.DateEnd as date) is null
		or try_cast(isnull(cs.FlagActive, 0) as bit) is null
		
               end
